### PR TITLE
fix: feature test srm

### DIFF
--- a/chrome-extension/src/content.js
+++ b/chrome-extension/src/content.js
@@ -73,7 +73,7 @@ const platforms = {
           let d = document.querySelectorAll('.performance-summary__column:first-child [data-test-section=performance-summary-cell-primary-value]');
           const iframeforweight = document.getElementById('iframeforweight');
           if (iframeforweight === null) return;
-          const weightnodes = iframeforweight.contentWindow.document.querySelectorAll('.oui-text-input[type=number]');
+          const weightnodes = iframeforweight.contentWindow.document.querySelectorAll('.oui-text-input[name="variation_percentage"]');
 
           if (d.length > 1 && weightnodes.length > 1) {
             const sessioncounts = [];


### PR DESCRIPTION
Fix for: 'problem is that the extension in the background is reading the traffic allocation for experiments and compares it to the number of users that saw the experiment. However this does not work correctly if the experiment is a "feature test" and not of type "A/B test".'